### PR TITLE
Fix uses of deprecated all caps constants.

### DIFF
--- a/example/dart_example/example_triangle.dart
+++ b/example/dart_example/example_triangle.dart
@@ -18,7 +18,7 @@ Float32List verts = new Float32List.fromList(const [
   0.0, 1.0, 0.0, 1.0, 0.0, 1.0,
   1.0, -1.0, 0.0, 0.0, 1.0, 1.0,
 ]);
-const int float32Size = Float32List.BYTES_PER_ELEMENT;
+const int float32Size = Float32List.bytesPerElement;
 
 const String vshader_text = """
 #version 100

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: gl
-version: "1.0.2"
+version: "1.0.3-dev"
 description: Dart GLES2 bindings
 authors:
   - John McDole <codefu@google.com>
@@ -8,7 +8,7 @@ authors:
   - Harry Stern <hstern@google.com>
 homepage:
 environment:
-  sdk: ">=1.0.0 <=2.0.0"
+  sdk: ">=2.0.0-dev.36.0 <3.0.0"
 dev_dependencies:
   args: ^0.13.7
   ccompile: "^0.2.10"

--- a/tools/gl_generator.dart
+++ b/tools/gl_generator.dart
@@ -65,7 +65,7 @@ main(List<String> args) async {
   for (var file in ['gl2.h', 'gl2ext.h']) {
     var readStream = new File(path.join(glPath, file)).openRead();
     await for (var line
-        in readStream.transform(UTF8.decoder).transform(new LineSplitter())) {
+        in readStream.transform(utf8.decoder).transform(new LineSplitter())) {
       if (line.startsWith('#define GL_')) {
         var match = CConst.defineReg.firstMatch(line);
         if (match == null) {


### PR DESCRIPTION
The old names will be going away when Dart 2 ships. The new names were
introduced in a previous dev version so now is a good time to switch to
them.