### PR TITLE
Prepare for upcoming change to File.openRead()

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: gl
-version: "1.0.3"
+version: "1.0.3+1"
 description: Dart GLES2 bindings
 authors:
   - John McDole <codefu@google.com>

--- a/tools/gl_generator.dart
+++ b/tools/gl_generator.dart
@@ -64,8 +64,10 @@ main(List<String> args) async {
   var extCalls = [];
   for (var file in ['gl2.h', 'gl2ext.h']) {
     var readStream = new File(path.join(glPath, file)).openRead();
-    await for (var line
-        in readStream.transform(utf8.decoder).transform(new LineSplitter())) {
+    await for (var line in readStream
+        .cast<List<int>>()
+        .transform(utf8.decoder)
+        .transform(new LineSplitter())) {
       if (line.startsWith('#define GL_')) {
         var match = CConst.defineReg.firstMatch(line);
         if (match == null) {


### PR DESCRIPTION
An upcoming change to the Dart SDK will change the signature
of `File.openRead()` from returning `Stream<List<int>>` to
returning `Stream<Uint8List>`.

This forwards-compatible change prepares for that SDK breaking
change by casting the Stream to `List<int>` before transforming
it.

https://github.com/dart-lang/sdk/issues/36900